### PR TITLE
Update _print-all-label-styles.scss

### DIFF
--- a/scss/tools/_print-all-label-styles.scss
+++ b/scss/tools/_print-all-label-styles.scss
@@ -1,10 +1,10 @@
-@import "settings/selectors";
-@import "settings/default-alignment";
-@import "settings/anchor-points";
-@import "settings/default-alignment";
+@import "../settings/selectors";
+@import "../settings/default-alignment";
+@import "../settings/anchor-points";
+@import "../settings/default-alignment";
 
-@import "tools/base-styles";
-@import "tools/attachments";
+@import "../tools/base-styles";
+@import "../tools/attachments";
 
 @mixin print-all-label-styles {
   #{unquote($corner-label-container-selector)} {


### PR DESCRIPTION
When using the package from npm (https://www.npmjs.com/package/corner-label), the package can't find imports. Can you update the npm package aswell?

Here is the error:
![imagen](https://user-images.githubusercontent.com/28898644/73956057-aa0e9280-4904-11ea-8c9f-def2d1e68ad2.png)
